### PR TITLE
adds manually add subcommand feature and adds installation in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,42 @@
 
 **dcli** is a nested functional-oriented cli (command line interface) python module. **dcli** does not require any other third-party module, it just wraps and encapsolutes [argparse](https://docs.python.org/3/library/argparse.html) in a decorator, i.e. `@dcli.command()`.
 
+## Getting Started
+
+Before installing, see [Requirements](#requirements) to check the dependencies.
+
+See [Installation](#installation) to install **dcli** to your local environment and [Usage](#usage) for more information about how to use.
+
+
 ## Requirements
 
 While **dcli** does not require any third-party, it requires run in Python with specific versions.
 
 - above Python 3.9
 
-## Getting Started
+## Installation
+
+Only one step to install **dcli**:
+
+```sh
+$ python3 -m pip install decorator-cli
+
+# pip list to check installation
+$ python3 -m pip list
+
+Package       Version
+------------- ---------
+decorator-cli <version>
+```
+
+## Usage
 
 To create our own command, just type following code:
 
 ```python
+import dcli
+...
+
 @dcli.command(
     "MyCommand",
     dcli.arg(...),

--- a/src/dcli/dcli.py
+++ b/src/dcli/dcli.py
@@ -39,18 +39,23 @@ class _CommandWrapper:
     Then calling |Command()| directly will invoke argpaser.parse_args() and pass return value into the origin function |Command(args)|.
     """
 
-    def __init__(self, fn: _Callable[[_Namespace], Any],
+    def __init__(self, name: str,
+                 fn: _Callable[[_Namespace], Any],
                  parser: _ArgumentParser,
                  *,
                  parent=None,
                  required_subcmd: bool = True,
                  skip_if_has_subcmd: bool = True) -> None:
+        self._name = name
         self._fn = fn
         self._parser = parser
         self._subparsers = None
         self._parent_cmd = parent
         self._required_sub = required_subcmd
         self._skip_if_has_subcmd = skip_if_has_subcmd
+
+    def __str__(self) -> str:
+        return self._name
 
     def __getSubCommand(self, args: _Namespace):
         if not hasattr(args, _SUBCMD_SPECIFIER) or not isinstance(getattr(args, _SUBCMD_SPECIFIER), _CommandWrapper):
@@ -225,7 +230,9 @@ def command(name: str,
             # root command condition.
             raw_parser = _ArgumentParser(**parser_kwargs)
 
-            cmd_wrapper = _CommandWrapper(func, raw_parser,
+            cmd_wrapper = _CommandWrapper(name,
+                                          func,
+                                          raw_parser,
                                           parent=None,
                                           required_subcmd=need_sub,
                                           skip_if_has_subcmd=skippable)
@@ -235,7 +242,9 @@ def command(name: str,
                 f"invalid parent for command |{name}|."
             sub_paresr = parent._addSubParser(name, help=help, **parser_kwargs)
 
-            cmd_wrapper = _CommandWrapper(func, sub_paresr,
+            cmd_wrapper = _CommandWrapper(name,
+                                          func,
+                                          sub_paresr,
                                           parent=parent,
                                           required_subcmd=need_sub,
                                           skip_if_has_subcmd=skippable)

--- a/src/dcli/dcli.py
+++ b/src/dcli/dcli.py
@@ -45,14 +45,19 @@ class _CommandWrapper:
                  *,
                  parent=None,
                  required_subcmd: bool = True,
-                 skip_if_has_subcmd: bool = True) -> None:
+                 skip_if_has_subcmd: bool = True,
+                 help: str = "",
+                 kwargs = None) -> None:
         self._name = name
         self._fn = fn
         self._parser = parser
         self._subparsers = None
+        self._subcommands: dict[str, _CommandWrapper] = {}
         self._parent_cmd = parent
         self._required_sub = required_subcmd
         self._skip_if_has_subcmd = skip_if_has_subcmd
+        self._brief_help = help
+        self._kwargs = kwargs
 
     def __str__(self) -> str:
         return self._name
@@ -80,17 +85,52 @@ class _CommandWrapper:
         elif not self._skip_if_has_subcmd or self == sub:
             return self._fn(args)
 
-    def _addSubParser(self, name: str, **kwargs) -> _ArgumentParser:
+    def _addSubCommand(self, *,
+                       name: str,
+                       func: _Callable[[_Namespace], Any],
+                       need_sub,
+                       help,
+                       skippable,
+                       **kwargs) -> _ArgumentParser:
+        assert name not in self._subcommands, \
+            f"add sub-command with duplicate name |{name}|."
         if self._subparsers == None:
             self._subparsers = self._getParser().add_subparsers()
         self._subparsers.required = self._required_sub
-        return self._subparsers.add_parser(name, **kwargs)
+
+        result = _CommandWrapper(name,
+                                 func,
+                                 self._subparsers.add_parser(name,
+                                                             help=help,
+                                                             **kwargs),
+                                 parent=self,
+                                 required_subcmd=need_sub,
+                                 skip_if_has_subcmd=skippable,
+                                 help=help,
+                                 kwargs=kwargs)
+
+        result._getParser().set_defaults(**{_SUBCMD_SPECIFIER: result})
+
+        self._subcommands[name] = result
+
+        return result
 
     def _getParser(self) -> _ArgumentParser:
         return self._parser
 
     def _addArgument(self, arg: _ArgumentWrapper):
         self._getParser().add_argument(*arg.args, **arg.kwargs)
+
+    def addSubCommand(self, cmd):
+        assert isinstance(cmd, _CommandWrapper), \
+            f"add invalid sub-command |{cmd}|."
+
+        self._addSubCommand(name=cmd._name,
+                            func=cmd._fn,
+                            need_sub=cmd._required_sub,
+                            help=cmd._brief_help,
+                            skippable=cmd._skip_if_has_subcmd,
+                            **cmd._kwargs)
 
 
 def arg(*name_or_flags: str,
@@ -235,21 +275,19 @@ def command(name: str,
                                           raw_parser,
                                           parent=None,
                                           required_subcmd=need_sub,
-                                          skip_if_has_subcmd=skippable)
+                                          skip_if_has_subcmd=skippable,
+                                          help=help,
+                                          kwargs=parser_kwargs)
         else:
             # sub command condition.
             assert isinstance(parent, _CommandWrapper), \
                 f"invalid parent for command |{name}|."
-            sub_paresr = parent._addSubParser(name, help=help, **parser_kwargs)
-
-            cmd_wrapper = _CommandWrapper(name,
-                                          func,
-                                          sub_paresr,
-                                          parent=parent,
-                                          required_subcmd=need_sub,
-                                          skip_if_has_subcmd=skippable)
-
-            sub_paresr.set_defaults(**{_SUBCMD_SPECIFIER: cmd_wrapper})
+            cmd_wrapper = parent._addSubCommand(name=name,
+                                                func=func,
+                                                need_sub=need_sub,
+                                                skippable=skippable,
+                                                help=help,
+                                                **parser_kwargs)
 
         # add arguments
         for arg in args:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -17,6 +17,23 @@ class TestCommand(unittest.TestCase):
 
         self.assertEqual(str(MyCommand), command_name)
 
+    def testReturnValue(self):
+        @dcli.command("bool-check",
+                      dcli.arg("-t", dest="val", default=False, action="store_true"))
+        def returnBool(ns):
+            return getattr(ns, "val")
+
+        self.assertFalse(returnBool([]))
+        self.assertTrue(returnBool(["-t"]))
+
+        @dcli.command("int-check",
+                      dcli.arg("-t", dest="val", default=0, type=int))
+        def returnInteger(ns):
+            return getattr(ns, "val")
+
+        self.assertEqual(returnInteger([]), 0)
+        self.assertEqual(returnInteger(["-t", "123"]), 123)
+
     def testCommandWrapper(self):
         val = None
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -8,6 +8,14 @@ from src import dcli
 
 class TestCommand(unittest.TestCase):
 
+    def testCommandName(self):
+        command_name = "test_command"
+        @dcli.command(command_name)
+        def MyCommand():
+            pass
+
+        self.assertEqual(str(MyCommand), command_name)
+
     def testCommandWrapper(self):
         val = None
         @dcli.command(


### PR DESCRIPTION
Now **dcli** can add subcommands manully by:

```python
@dcli.command(...)
def Command(ns):
    ...

@dcli.command(...)
def SubCommand(ns):
    ...

Command.addSubCommand(SubCommand)
```